### PR TITLE
update @pinpt/email to 1.0.0 📦

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.13",
       "dependencies": {
         "@pinpt/cli": "^1.0.1",
-        "@pinpt/email": "^0.0.8",
+        "@pinpt/email": "^1.0.0",
         "@pinpt/react": "^0.6.5",
         "encoding": "^0.1.13",
         "next": "11.1.0",
@@ -554,9 +554,9 @@
       }
     },
     "node_modules/@pinpt/email": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@pinpt/email/-/email-0.0.8.tgz",
-      "integrity": "sha512-7veyDO0wXkuIBCgEt8kKz9Iqi59crIrF7lBkmbJKvjiy55ZW2AaNT6nI4ip2itNFJ5ldp5sxUkh+Um8DjUlYeg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pinpt/email/-/email-1.0.0.tgz",
+      "integrity": "sha512-Sid3XmVnPgOZkvs32Ej9cIiECYenQ2en70hDaVi6QXD8FHW3I/j4NRLIT5Ac6MymIg39+H2di/U7FSSEgFt3VA==",
       "dependencies": {
         "handlebars": "^4.7.7"
       }
@@ -7709,9 +7709,9 @@
       }
     },
     "@pinpt/email": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@pinpt/email/-/email-0.0.8.tgz",
-      "integrity": "sha512-7veyDO0wXkuIBCgEt8kKz9Iqi59crIrF7lBkmbJKvjiy55ZW2AaNT6nI4ip2itNFJ5ldp5sxUkh+Um8DjUlYeg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@pinpt/email/-/email-1.0.0.tgz",
+      "integrity": "sha512-Sid3XmVnPgOZkvs32Ej9cIiECYenQ2en70hDaVi6QXD8FHW3I/j4NRLIT5Ac6MymIg39+H2di/U7FSSEgFt3VA==",
       "requires": {
         "handlebars": "^4.7.7"
       }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@pinpt/cli": "^1.0.1",
-    "@pinpt/email": "^0.0.8",
+    "@pinpt/email": "^1.0.0",
     "@pinpt/react": "^0.6.5",
     "encoding": "^0.1.13",
     "next": "11.1.0",

--- a/pinpoint.next.js
+++ b/pinpoint.next.js
@@ -1,3 +1,5 @@
+const fs = require('fs');
+const path = require('path');
 const { apihost, siteId } = require('./pinpoint.config.js');
 const homeurl = (apihost || '').includes('.edge.') ? `https://home.edge.pinpoint.com` : `https://home.pinpoint.com`;
 
@@ -116,6 +118,11 @@ const withPinpointConfig = (config) => {
 	const _config = { ...config };
 	_config.headers = createHeaderWrapper(_config.headers);
 	_config.rewrites = createRewriteWrapper(_config.rewrites);
+	// load up build-time config
+	if (fs.existsSync(path.join(__dirname, 'pinpoint.config.json'))) {
+		const buildConfig = JSON.parse(fs.readFileSync(path.join(__dirname, 'pinpoint.config.json')).toString());
+		return { ..._config, ...buildConfig };
+	}
 	return _config;
 };
 


### PR DESCRIPTION
`@pinpt/email` is now stable. You should update to it since npm won't update pre `1.0.0` versions since they're considered _unstable_. Also theres a bug in v0 where the `Most Recent` section of the email skips the first one after the subject.