### PR TITLE
Fixes type errors trying to build subscription pages

### DIFF
--- a/components/Subscription/Unsubscribe.tsx
+++ b/components/Subscription/Unsubscribe.tsx
@@ -51,8 +51,8 @@ const SubscriptionUnsubscribe = ({ site }: { site: ISite }) => {
 		<PrebuiltSubscriptionUnsubscribe
 			site={site}
 			email={subscription.email}
-			renderHeader={(site) => <Header site={site} noSubscribe />}
-			renderFooter={(site) => <Footer site={site} noSubscribe />}
+			renderHeader={(site) => <Header site={site} />}
+			renderFooter={(site) => <Footer site={site} />}
 			handleSelectHome={() => router.push(getRouterRelativePath(site, '/'))}
 			handleSubscribe={handleSubscribe}
 			handleUnsubscribe={handleUnSubscribe}

--- a/components/Subscription/Verify.tsx
+++ b/components/Subscription/Verify.tsx
@@ -40,8 +40,8 @@ const SubscriptionVerify = ({ site }: { site: ISite }) => {
 	return (
 		<PrebuiltSubscriptionVerify
 			site={site}
-			renderHeader={(site) => <Header site={site} noSubscribe />}
-			renderFooter={(site) => <Footer site={site} noSubscribe />}
+			renderHeader={(site) => <Header site={site} />}
+			renderFooter={(site) => <Footer site={site} />}
 			handleSelectHome={() => router.push(getRouterRelativePath(site, '/'))}
 			verified={verified}
 			firstName={firstName}


### PR DESCRIPTION
These type errors slipped by me, so this PR removes the props from the default version to suit your header and footer components.

I've attached how this looks out of the box from our default theme. If you want to restyle it I can wait until you're ready to move traffic to use these new subscription management screens.

![Screen Shot 2021-11-24 at 11 22 30 AM](https://user-images.githubusercontent.com/12700819/143286644-67c6b7c9-4e92-463a-ab1d-bfb09897ce6b.png)


![Screen Shot 2021-11-24 at 11 29 23 AM](https://user-images.githubusercontent.com/12700819/143287022-8f9bf2cc-4c31-45e3-9d82-1f8fb6385308.png)

![Screen Shot 2021-11-24 at 11 29 38 AM](https://user-images.githubusercontent.com/12700819/143287096-4c569c60-28d0-45a7-977a-328874e637e4.png)

![Screen Shot 2021-11-24 at 11 31 01 AM](https://user-images.githubusercontent.com/12700819/143287139-0129bd2d-db89-401c-b00d-ce43365b7db8.png)


